### PR TITLE
Fix to hash

### DIFF
--- a/lib/lightblue/ast/visitors/hash_visitor.rb
+++ b/lib/lightblue/ast/visitors/hash_visitor.rb
@@ -68,7 +68,7 @@ module Lightblue
 
         def on_object_type(node)
           v, = *node
-          node.updated(nil, [{ objectType: v }])
+          node.updated(nil, [{ entity: v }])
         end
       end
     end

--- a/lib/lightblue/ast/visitors/hash_visitor.rb
+++ b/lib/lightblue/ast/visitors/hash_visitor.rb
@@ -68,7 +68,7 @@ module Lightblue
 
         def on_object_type(node)
           v, = *node
-          node.updated(nil, [{ entity: v }])
+          node.updated(nil, [{ objectType: v }])
         end
       end
     end

--- a/lib/lightblue/ast/visitors/validation_visitor.rb
+++ b/lib/lightblue/ast/visitors/validation_visitor.rb
@@ -177,6 +177,9 @@ module Lightblue
           nil
         end
 
+        def on_basic_projection_array(node)
+        end
+
         def on_range(node)
           child, = *node
           fail InvalidRange if child.length > 2

--- a/lib/lightblue/find_manager.rb
+++ b/lib/lightblue/find_manager.rb
@@ -21,7 +21,7 @@ module Lightblue
     end
 
     def ast
-      @expression.ast
+      @expression.ast if @expression
     end
 
     def unary_logical_operator(token, expr = nil, &blk)

--- a/lib/lightblue/projection.rb
+++ b/lib/lightblue/projection.rb
@@ -112,12 +112,11 @@ module Lightblue
 
     def ast
       if @projections.count > 1
-        AST::Node.new(:projection,
-                      [AST::Node.new(:basic_projection_array, @projections.map(&:ast))])
+        AST::Node.new(:basic_projection_array, @projections.map(&:ast))
       elsif @projections.count == 1
         @projections.first.ast
       else
-        []
+        nil
       end
     end
   end

--- a/lib/lightblue/projection.rb
+++ b/lib/lightblue/projection.rb
@@ -115,8 +115,6 @@ module Lightblue
         AST::Node.new(:basic_projection_array, @projections.map(&:ast))
       elsif @projections.count == 1
         @projections.first.ast
-      else
-        nil
       end
     end
   end

--- a/lib/lightblue/query.rb
+++ b/lib/lightblue/query.rb
@@ -42,7 +42,11 @@ module Lightblue
     end
 
     def to_hash
-      { entity: @entity.name, entityVersion: @entity.version, query: find_hash, projection: [projection_hash].flatten }.delete_if { |_, v| v.nil? }
+      { entity: @entity.name,
+        entityVersion: @entity.version,
+        query: find_hash,
+        projection: [projection_hash].flatten
+      }.delete_if { |_, v| v.nil? }
     end
 
     private
@@ -51,12 +55,10 @@ module Lightblue
       if projection_ast
         p = ast_to_hash(validate(unfold(projection_ast)))
         if p.type == :basic_projection_array
-          p.children.map{|x| x.children}.flatten
+          p.children.map(&:children).flatten
         else
           p.children
         end
-      else
-        nil
       end
     end
 
@@ -69,12 +71,8 @@ module Lightblue
     end
 
     def find_hash
-      if find_ast
-        h, = *ast_to_hash(validate(unfold(find_ast)))
-        h
-      else
-        nil
-      end
+      h, = *ast_to_hash(validate(unfold(find_ast))) if find_ast
+      h
     end
 
     def ast_to_hash(ast)

--- a/test/lightblue/query_test.rb
+++ b/test/lightblue/query_test.rb
@@ -90,21 +90,22 @@ describe 'queryin\'' do
         query: {
           field: :bar, op: :$eq, rvalue: :foo
         },
-        projection: {
+        projection: [{
           field: :foo,
           include: true,
           range: [1, 2],
           project: {
             field: :bar, include: false
           }
-        }
+        }]
       }
       assert_equal expected, query.to_hash
     end
 
     it 'should render the correct hash' do
       expected =
-        { entity: :foo,
+        {
+          entity: :foo,
           query:
             { :$all =>
               [
@@ -117,14 +118,14 @@ describe 'queryin\'' do
                 }
               ]
             },
-          projection: {
+          projection: [{
             field: :bar,
             include: true,
             match: {
               field: :flim,
               op: :$eq,
               rvalue: :flam }
-          }
+          }]
         }
 
       query = Lightblue::Query.new(entity).find do


### PR DESCRIPTION
- Allows to_hash to be called on a query that has no projection or find
  expressions set
- Sets entity/entityVersion on to_hash
- to_hash no longer ignores multiple projection fields

These are just quick fixes ahead of the larger refactor.